### PR TITLE
Fix deadlock dismissing dialog

### DIFF
--- a/AndHUD/XHUD.cs
+++ b/AndHUD/XHUD.cs
@@ -24,7 +24,7 @@ namespace XHUD
 
 		public static void Dismiss()
 		{
-			AndHUD.Shared.Dismiss(HUD.MyActivity);
+			AndHUD.Shared.Dismiss();
 		}
 
 		public static void ShowToast(string message, bool showToastCentered = true, double timeoutMs = 1000)

--- a/Sample/MainActivity.cs
+++ b/Sample/MainActivity.cs
@@ -22,7 +22,8 @@ public class MainActivity : AppCompatActivity
         "Click Callback",
         "Cancellable Callback",
         "Long Message",
-        "Really Long Message"
+        "Really Long Message",
+        "Deadlock"
     };
 
     private ListView _listView;
@@ -106,7 +107,19 @@ public class MainActivity : AppCompatActivity
                 case "Really Long Message":
                     AndHUD.Shared.Show(this, "This is a really really long message to display as a status indicator, so you should shorten it!", -1, MaskType.Black, TimeSpan.FromSeconds(3));
                     break;
+                case "Deadlock":
+                    DeadlockScenario();
+                    break;
             }
+            }
+
+    private async void DeadlockScenario()
+    {
+        AndHUD.Shared.ShowToast(this, "Deadlocking!", MaskType.None, null, true, null, () => AndHUD.Shared.Dismiss());
+
+        Task.Run(() => AndHUD.Shared.Dismiss());
+        await Task.Delay(1);
+        AndHUD.Shared.Dismiss();
         }
 
         void ShowProgressDemo(Action<int> action)

--- a/Sample/MainActivity.cs
+++ b/Sample/MainActivity.cs
@@ -96,10 +96,10 @@ public class MainActivity : AppCompatActivity
                     AndHUD.Shared.ShowImage(this, Sample.Resource.Drawable.ic_questionstatus, "Custom Image...", MaskType.Black, TimeSpan.FromSeconds(3));
                     break;
                 case "Click Callback":
-                    AndHUD.Shared.ShowToast(this, "Click this toast to close it!", MaskType.Clear, null, true, () => AndHUD.Shared.Dismiss(this));
+                    AndHUD.Shared.ShowToast(this, "Click this toast to close it!", MaskType.Clear, null, true, () => AndHUD.Shared.Dismiss());
                     break;
                 case "Cancellable Callback":
-                    AndHUD.Shared.ShowToast(this, "Click back button to cancel/close it!", MaskType.None, null, true, null, () => AndHUD.Shared.Dismiss(this));
+                    AndHUD.Shared.ShowToast(this, "Click back button to cancel/close it!", MaskType.None, null, true, null, () => AndHUD.Shared.Dismiss());
                     break;
                 case "Long Message":
                     AndHUD.Shared.Show(this, "This is a longer message to display!", -1, MaskType.Black, TimeSpan.FromSeconds(3));
@@ -111,7 +111,7 @@ public class MainActivity : AppCompatActivity
                     DeadlockScenario();
                     break;
             }
-            }
+        }
 
     private async void DeadlockScenario()
     {
@@ -120,9 +120,9 @@ public class MainActivity : AppCompatActivity
         Task.Run(() => AndHUD.Shared.Dismiss());
         await Task.Delay(1);
         AndHUD.Shared.Dismiss();
-        }
+    }
 
-        void ShowProgressDemo(Action<int> action)
+    void ShowProgressDemo(Action<int> action)
         {
             Task.Run(() => {
                 int progress = 0;
@@ -135,7 +135,7 @@ public class MainActivity : AppCompatActivity
                     progress += 10;
                 }
 
-                AndHUD.Shared.Dismiss(this);
+                AndHUD.Shared.Dismiss();
             });
         }
 
@@ -147,7 +147,7 @@ public class MainActivity : AppCompatActivity
 
                 new ManualResetEvent(false).WaitOne(3000);
 
-                AndHUD.Shared.Dismiss(this);
+                AndHUD.Shared.Dismiss();
             });
         }
 }

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -23,7 +23,4 @@
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.7.0.2" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Resources\drawable" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Deadlock if you call Dismiss() from both background and UI thread at the same time

### :new: What is the new behavior (if this is a feature change)?
Switching away from using ManualResetEvent and locks to SemaphoreSlim

Also. Application.SynchronizationContext cannot be null, so removed the logic to check it for null, which it can't be and fallbacks

### :boom: Does this PR introduce a breaking change?
Dismiss() doesn't take a Context anymore

### :bug: Recommendations for testing
Added new item "Deadlock" in the sample. Call it, even spam the item. App should not end up with MainActivity locking up

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
