### PR TITLE
Bugfix/semaphoreslim timeouts

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.2.0",
+      "version": "4.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Setup .NET 7
+    - name: Setup .NET 8
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
 
     - name: Install workload
       run: dotnet workload install android

--- a/AndHUD.sln
+++ b/AndHUD.sln
@@ -10,8 +10,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 		build.cake = build.cake
 		.github\workflows\build.yml = .github\workflows\build.yml
 		Directory.build.props = Directory.build.props
-		Directory.build.targets = Directory.build.targets
-		global.json = global.json
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/AndHUD/AndHUD.cs
+++ b/AndHUD/AndHUD.cs
@@ -13,7 +13,9 @@ using Android.Widget;
 namespace AndroidHUD
 {
     public class AndHUD
-	{
+    {
+        private const string TagName = nameof(AndHUD);
+        
 		static AndHUD shared;
 
 		public static AndHUD Shared
@@ -86,7 +88,11 @@ namespace AndroidHUD
 
 		public void Dismiss()
 		{
-            _semaphoreSlim.Wait();
+            if (!_semaphoreSlim.Wait(1000))
+            {
+                Log.Warn(TagName, "Timed out getting semaphore on Dismiss()");
+                return;
+            }
             try
             {
                 DismissCurrent ();
@@ -116,10 +122,15 @@ namespace AndroidHUD
 			if (timeout == null)
 				timeout = TimeSpan.Zero;
 
-			if (CurrentDialog != null && statusObj == null)
-				DismissCurrent ();
-            
-            _semaphoreSlim.Wait();
+            if (!_semaphoreSlim.Wait(1000))
+            {
+                Log.Warn(TagName, "Timed out getting semaphore on showStatus()");
+                return;
+            }
+
+            if (CurrentDialog != null && statusObj == null)
+                DismissCurrent ();
+
             try
             {
                 if (CurrentDialog == null)
@@ -190,10 +201,15 @@ namespace AndroidHUD
 		{
 			timeout ??= TimeSpan.Zero;
 
-			if (CurrentDialog != null && progressWheel == null)
-				DismissCurrent ();
+            if (!_semaphoreSlim.Wait(1000))
+            {
+                Log.Warn(TagName, "Timed out getting semaphore on showProgress()");
+                return;
+            }
+            
+            if (CurrentDialog != null && progressWheel == null)
+                DismissCurrent ();
 
-            _semaphoreSlim.Wait();
             try
             {
                 if (CurrentDialog == null)
@@ -243,10 +259,14 @@ namespace AndroidHUD
 			if (timeout == null)
 				timeout = TimeSpan.Zero;
 
-			if (CurrentDialog != null && imageView == null)
-				DismissCurrent ();
+            if (!_semaphoreSlim.Wait(1000))
+            {
+                Log.Warn(TagName, "Timed out getting semaphore on showImage()");
+                return;
+            }
 
-            _semaphoreSlim.Wait();
+            if (CurrentDialog != null && imageView == null)
+                DismissCurrent ();
             try
             {
                 if (CurrentDialog == null)
@@ -302,7 +322,7 @@ namespace AndroidHUD
                 }
                 catch (Exception e)
                 {
-                    Log.Error("AndHUD", e.ToString());
+                    Log.Error(TagName, e.ToString());
                 }
             }
         }
@@ -358,7 +378,7 @@ namespace AndroidHUD
                     }
                     catch (Exception ex)
                     {
-                        Log.Error("AndHUD", "Failed to dismiss dialog {0}", ex.ToString());
+                        Log.Error(TagName, "Failed to dismiss dialog {0}", ex.ToString());
                     }
                     finally
                     {

--- a/AndHUD/AndHUD.csproj
+++ b/AndHUD/AndHUD.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Net.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0-android;net7.0-android</TargetFrameworks>
+    <TargetFrameworks>net7.0-android;net8.0-android</TargetFrameworks>
     <AssemblyName>AndHUD</AssemblyName>
     <RootNamespace>AndroidHUD</RootNamespace>
     <PackageId>AndHUD</PackageId>

--- a/AndHUD/AndHUD.csproj
+++ b/AndHUD/AndHUD.csproj
@@ -14,5 +14,9 @@
     <AndroidResource Include="Resources\**\*.xml" />
     <AndroidResource Include="Resources\**\*.png" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+  </ItemGroup>
   
 </Project>

--- a/Sample/MainActivity.cs
+++ b/Sample/MainActivity.cs
@@ -1,4 +1,5 @@
-﻿using AndroidHUD;
+﻿using Android.Content;
+using AndroidHUD;
 using AndroidX.AppCompat.App;
 
 namespace SampleNet6;
@@ -116,7 +117,27 @@ public class MainActivity : AppCompatActivity
     private async void DeadlockScenario()
     {
         AndHUD.Shared.ShowToast(this, "Deadlocking!", MaskType.None, null, true, null, () => AndHUD.Shared.Dismiss());
+        
+        StartActivity(new Intent(this, typeof(SecondActivity)));
 
+        await Task.WhenAll([
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+            Task.Run(() => AndHUD.Shared.Dismiss()),
+        ]);
+        
         Task.Run(() => AndHUD.Shared.Dismiss());
         await Task.Delay(1);
         AndHUD.Shared.Dismiss();

--- a/Sample/Resources/layout/activity_second.xml
+++ b/Sample/Resources/layout/activity_second.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+    <TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
+              android:text="I am second" android:layout_gravity="center" />
+</LinearLayout>

--- a/Sample/Resources/values/strings.xml
+++ b/Sample/Resources/values/strings.xml
@@ -1,4 +1,3 @@
 <resources>
-    <string name="app_name">SampleNet6</string>
-    <string name="app_text">Hello, Android!</string>
+    <string name="app_name">AndHUD</string>
 </resources>

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -1,16 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-      <TargetFramework>net7.0-android</TargetFramework>
-      <SupportedOSPlatformVersion>22</SupportedOSPlatformVersion>
+      <TargetFramework>net8.0-android</TargetFramework>
       <OutputType>Exe</OutputType>
+      <SupportedOSPlatformVersion>22</SupportedOSPlatformVersion>
       <Nullable>enable</Nullable>
       <ImplicitUsings>enable</ImplicitUsings>
       <ApplicationId>com.companyname.SampleNet6</ApplicationId>
       <ApplicationVersion>1</ApplicationVersion>
       <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-      <LangVersion>latest</LangVersion>
-      <IsPackable>False</IsPackable>
-      <AndroidGenerateResourceDesigner>true</AndroidGenerateResourceDesigner>
     </PropertyGroup>
 
     <ItemGroup>
@@ -18,9 +15,9 @@
     </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.6.1.1" />
-    <PackageReference Include="Xamarin.AndroidX.Fragment" Version="1.5.5.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.7.0.2" />
+    <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.8.2.1" />
+    <PackageReference Include="Xamarin.AndroidX.Fragment" Version="1.6.2.2" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/Sample/SecondActivity.cs
+++ b/Sample/SecondActivity.cs
@@ -1,0 +1,15 @@
+﻿using AndroidX.AppCompat.App;
+using Sample;
+
+namespace SampleNet6;
+
+[Activity(Label = "Second")]
+public class SecondActivity : AppCompatActivity
+{
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+        
+        SetContentView(Resource.Layout.activity_second);
+    }
+}

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
-#tool nuget:?package=GitVersion.CommandLine&version=5.10.3
-#addin nuget:?package=Cake.Figlet&version=2.0.1
+#tool dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=5.12.0
+#addin nuget:https://api.nuget.org/v3/index.json?package=Cake.Figlet&version=2.0.1
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
I have a production app where the App ends up in a deadlock because somehow the calling `SemaphoreSlim.Wait` inside of AndHUD ends up in a deadlock.

### :new: What is the new behavior (if this is a feature change)?
I haven't been able to narrow down what exactly causes this, but it mainly happens when trying to dismiss AndHUD that is showing on Activity A, while navigating to Activity B.

### :boom: Does this PR introduce a breaking change?
Worst case AndHUD won't dismiss if there is a timeout waiting for the semaphore.

### :bug: Recommendations for testing
Try the bottom most "Deadlock" item in the Sample App

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
